### PR TITLE
docs: fix project's license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Don't forget to give the project a star! Thanks again!
 
 ## License
 
-Distributed under the MIT License. See `LICENSE.txt` for more information.
+Distributed under the GPL License. See [LICENSE](LICENSE) for more information.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 


### PR DESCRIPTION
fix project's license section with the correct current license and a link to it